### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,7 +87,7 @@ function processMessage(obj) {
 }
 
 function decodeHome(ip, message) {
-    const values = message.toString('ascii').split(/[\s_?]/);
+    const values = message.toString('ascii').split(/[;_?]/);
     if (values.length < 6) {
         adapter.log.warn(`Invalid packet length! ${values.join('_')}`);
     } else
@@ -107,7 +107,7 @@ function decodeHome(ip, message) {
 }
 
 function decodeMulti(ip, message) {
-    const values = message.toString('ascii').split(/[\s_?]/);
+    const values = message.toString('ascii').split(/[;_?]/);
     if (values.length < 6) {
         adapter.log.warn(`Invalid packet length! ${values.join('_')}`);
     } else


### PR DESCRIPTION
Leerzeichen/blank/space als Separator führt zum von mir gemeldeten Fehler. Name darf z.B. bei Adelstiteln ein blank enthalten. Am Ende eines Namens kann bei Eingabe in ekey-Multi-Zentrale auch irrtümlich ein blank angefügt werden; durch das kleine Display ist das kaum zu erkennen. Korrektur eines falsch eingegebenen Namens ist nicht möglich, löschen & Neueingabe aufwändig.
Daher macht es Sinn, blank als Separator rauszunehmen. Semikolon als Separator wäre sinnvoller Ersatz, da bei Namenseingabe definitiv falsch und gut erkennbar.